### PR TITLE
feat(web2md): implement Zenn support (SMA-22)

### DIFF
--- a/provider/web2md/sites/index.ts
+++ b/provider/web2md/sites/index.ts
@@ -1,6 +1,7 @@
 import type { SiteHandler } from './base.js'
 import { DefaultSiteHandler } from './default.js'
 import { QiitaSiteHandler } from './qiita.js'
+import { ZennSiteHandler } from './zenn.js'
 
 /**
  * All available site handlers
@@ -8,6 +9,7 @@ import { QiitaSiteHandler } from './qiita.js'
 const SITE_HANDLERS: SiteHandler[] = [
     // Specific site handlers (placed before DefaultSiteHandler for priority)
     new QiitaSiteHandler(),
+    new ZennSiteHandler(),
 
     // DefaultSiteHandler should always be last (catches all URLs)
     new DefaultSiteHandler(),
@@ -36,3 +38,4 @@ export function getAllSiteHandlers(): readonly SiteHandler[] {
 export type { SiteHandler, ExtractedContent } from './base.js'
 export { DefaultSiteHandler } from './default.js'
 export { QiitaSiteHandler } from './qiita.js'
+export { ZennSiteHandler } from './zenn.js'

--- a/provider/web2md/sites/zenn.test.ts
+++ b/provider/web2md/sites/zenn.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest'
+import { ZennSiteHandler } from './zenn.js'
+
+describe('ZennSiteHandler', () => {
+    const handler = new ZennSiteHandler()
+
+    describe('urlPattern', () => {
+        it('should match valid Zenn article URLs', () => {
+            const validUrls = [
+                'https://zenn.dev/user123/articles/article-id',
+                'https://zenn.dev/test-user/articles/test-article',
+                'https://zenn.dev/pepabo/articles/99042d27d6cf3b',
+            ]
+
+            for (const url of validUrls) {
+                expect(handler.urlPattern.test(url)).toBe(true)
+            }
+        })
+
+        it('should match valid Zenn book URLs', () => {
+            const validUrls = [
+                'https://zenn.dev/user123/books/book-id',
+                'https://zenn.dev/test-user/books/test-book',
+            ]
+
+            for (const url of validUrls) {
+                expect(handler.urlPattern.test(url)).toBe(true)
+            }
+        })
+
+        it('should not match invalid URLs', () => {
+            const invalidUrls = [
+                'https://zenn.dev/',
+                'https://zenn.dev/trending',
+                'https://zenn.dev/user123',
+                'https://example.com',
+                'https://qiita.com/user/items/123',
+                'http://zenn.dev/user/articles/123', // http instead of https
+            ]
+
+            for (const url of invalidUrls) {
+                expect(handler.urlPattern.test(url)).toBe(false)
+            }
+        })
+    })
+
+    describe('extractContent', () => {
+        it('should extract content from __NEXT_DATA__ JSON', () => {
+            const html = `
+                <html>
+                <head><title>Test Article - Zenn</title></head>
+                <body>
+                    <script id="__NEXT_DATA__" type="application/json">
+                    {
+                        "props": {
+                            "pageProps": {
+                                "article": {
+                                    "title": "Next.js Article Title",
+                                    "bodyHtml": "<h1>Content from JSON</h1><p>This is the article body from JSON.</p>"
+                                }
+                            }
+                        }
+                    }
+                    </script>
+                    <div class="znc">
+                        <h1>DOM Content</h1>
+                        <p>This should not be used when JSON is available.</p>
+                    </div>
+                </body>
+                </html>
+            `
+
+            const result = handler.extractContent(html)
+
+            expect(result).not.toBeNull()
+            expect(result?.title).toBe('Next.js Article Title')
+            expect(result?.content).toContain('Content from JSON')
+            expect(result?.content).toContain('This is the article body from JSON')
+            expect(result?.content).not.toContain('DOM Content')
+        })
+
+        it('should fallback to .znc selector when __NEXT_DATA__ is not available', () => {
+            const html = `
+                <html>
+                <head><title>Fallback Test - Zenn</title></head>
+                <body>
+                    <div class="znc">
+                        <h1>Zenn Article</h1>
+                        <p>Content from DOM selector.</p>
+                    </div>
+                </body>
+                </html>
+            `
+
+            const result = handler.extractContent(html)
+
+            expect(result).not.toBeNull()
+            expect(result?.title).toBe('Zenn Article')
+            expect(result?.content).toContain('Zenn Article')
+            expect(result?.content).toContain('Content from DOM selector')
+        })
+
+        it('should handle invalid __NEXT_DATA__ JSON gracefully', () => {
+            const html = `
+                <html>
+                <head><title>Invalid JSON Test - Zenn</title></head>
+                <body>
+                    <script id="__NEXT_DATA__" type="application/json">
+                    { invalid json }
+                    </script>
+                    <article>
+                        <h1>Fallback Article</h1>
+                        <p>Should use DOM extraction when JSON is invalid.</p>
+                    </article>
+                </body>
+                </html>
+            `
+
+            const result = handler.extractContent(html)
+
+            expect(result).not.toBeNull()
+            expect(result?.title).toBe('Fallback Article')
+            expect(result?.content).toContain('Should use DOM extraction')
+        })
+
+        it('should return null for empty content', () => {
+            const html = `
+                <html>
+                <head><title>Empty - Zenn</title></head>
+                <body>
+                    <div class="znc"></div>
+                </body>
+                </html>
+            `
+
+            const result = handler.extractContent(html)
+
+            expect(result).toBeNull()
+        })
+    })
+
+    describe('extractTitle', () => {
+        it('should extract title from data-testid="article-title"', () => {
+            const html = `
+                <html>
+                <body>
+                    <h1 data-testid="article-title">Specific Zenn Title</h1>
+                </body>
+                </html>
+            `
+
+            const doc = new DOMParser().parseFromString(html, 'text/html')
+            const title = handler.extractTitle(doc)
+
+            expect(title).toBe('Specific Zenn Title')
+        })
+
+        it('should extract title from og:title meta tag', () => {
+            const html = `
+                <html>
+                <head>
+                    <meta property="og:title" content="OG Title for Zenn">
+                    <title>Page Title | Zenn</title>
+                </head>
+                <body></body>
+                </html>
+            `
+
+            const doc = new DOMParser().parseFromString(html, 'text/html')
+            const title = handler.extractTitle(doc)
+
+            expect(title).toBe('OG Title for Zenn')
+        })
+
+        it('should remove Zenn suffix from title tag', () => {
+            const html = `
+                <html>
+                <head><title>Article Title | Zenn</title></head>
+                <body></body>
+                </html>
+            `
+
+            const doc = new DOMParser().parseFromString(html, 'text/html')
+            const title = handler.extractTitle(doc)
+
+            expect(title).toBe('Article Title')
+        })
+
+        it('should return null for missing title', () => {
+            const html = `
+                <html>
+                <head></head>
+                <body></body>
+                </html>
+            `
+
+            const doc = new DOMParser().parseFromString(html, 'text/html')
+            const title = handler.extractTitle(doc)
+
+            expect(title).toBeNull()
+        })
+    })
+
+    describe('getTurndownRules', () => {
+        it('should include common rules and Zenn-specific rules', () => {
+            const rules = handler.getTurndownRules()
+
+            expect(rules.length).toBeGreaterThan(2)
+
+            const ruleNames = rules.map(r => r.name)
+            expect(ruleNames).toContain('removeHeadingLinks')
+            expect(ruleNames).toContain('defaultCodeBlocks')
+            expect(ruleNames).toContain('zennCodeBlocks')
+            expect(ruleNames).toContain('zennCallouts')
+            expect(ruleNames).toContain('removeImages')
+        })
+
+        it('should convert Zenn code blocks with language detection', () => {
+            const html = `<pre><code class="language-typescript">const x = 1;</code></pre>`
+
+            const doc = new DOMParser().parseFromString(html, 'text/html')
+            const preElement = doc.querySelector('pre')!
+
+            const rules = handler.getTurndownRules()
+            const zennCodeRule = rules.find(r => r.name === 'zennCodeBlocks')!
+            const markdown = zennCodeRule.replacement('', preElement)
+
+            expect(markdown).toContain('```typescript')
+            expect(markdown).toContain('const x = 1;')
+        })
+
+        it('should convert Zenn callouts with appropriate icons', () => {
+            const htmlAlert = `<div class="msg alert">Alert message</div>`
+            const htmlMessage = `<div class="msg message">Info message</div>`
+            const htmlDefault = `<div class="msg">Default message</div>`
+
+            const doc = new DOMParser().parseFromString(htmlAlert + htmlMessage + htmlDefault, 'text/html')
+
+            const rules = handler.getTurndownRules()
+            const calloutRule = rules.find(r => r.name === 'zennCallouts')!
+
+            const alertElement = doc.querySelector('.msg.alert')!
+            const messageElement = doc.querySelector('.msg.message')!
+            const defaultElement = doc.querySelector('.msg:not(.alert):not(.message)')!
+
+            expect(calloutRule.replacement('Alert message', alertElement)).toContain('> 🚨 Alert message')
+            expect(calloutRule.replacement('Info message', messageElement)).toContain('> ℹ️ Info message')
+            expect(calloutRule.replacement('Default message', defaultElement)).toContain('> 💡 Default message')
+        })
+    })
+
+})

--- a/provider/web2md/sites/zenn.ts
+++ b/provider/web2md/sites/zenn.ts
@@ -1,0 +1,149 @@
+import { parseHTML, extractContentBySelector, getFallbackTitle } from './base.js'
+import type { SiteHandler, ExtractedContent } from './base.js'
+import type { TurndownRule } from '../types.js'
+import { COMMON_RULES } from '../common/rules.js'
+
+/**
+ * Zenn site handler
+ * Optimized for Zenn article and book pages with better content extraction
+ */
+export class ZennSiteHandler implements SiteHandler {
+    /** Matches Zenn article and book URLs */
+    urlPattern = /^https:\/\/zenn\.dev\/[\w-]+\/(articles|books)\/[\w-]+/
+
+    extractContent(html: string): ExtractedContent | null {
+        const doc = parseHTML(html)
+
+        // First, try to extract from __NEXT_DATA__ (recommended approach for Zenn)
+        const nextDataScript = doc.querySelector('#__NEXT_DATA__')
+        if (nextDataScript?.textContent) {
+            try {
+                const data = JSON.parse(nextDataScript.textContent)
+                const article = data?.props?.pageProps?.article
+
+                if (article?.bodyHtml && article?.title) {
+                    return {
+                        title: article.title,
+                        content: article.bodyHtml,
+                    }
+                }
+            } catch (error) {
+                console.warn('[web2md] Failed to parse __NEXT_DATA__:', error)
+            }
+        }
+
+        // Fallback to DOM-based extraction
+        // Try Zenn-specific content selector first
+        let content = extractContentBySelector(doc, '.znc')
+
+        // Fallback to article content
+        if (!content.trim()) {
+            content = extractContentBySelector(doc, 'article')
+        }
+
+        // Last resort: main content area
+        if (!content.trim()) {
+            content = extractContentBySelector(doc, 'main')
+        }
+
+        if (!content.trim()) {
+            return null
+        }
+
+        const title = this.extractTitle(doc) || getFallbackTitle(doc)
+
+        return {
+            title,
+            content,
+        }
+    }
+
+    extractTitle(doc: Document): string | null {
+        // Try Zenn-specific title selectors
+        const selectors = [
+            'h1[data-testid="article-title"]',
+            '.View_title__VsTaR',
+            'article h1',
+            'h1', // fallback
+        ]
+
+        for (const selector of selectors) {
+            const element = doc.querySelector(selector)
+            if (element?.textContent?.trim()) {
+                return element.textContent.trim()
+            }
+        }
+
+        // Try meta tags
+        const ogTitle = doc.querySelector('meta[property="og:title"]')?.getAttribute('content')
+        if (ogTitle?.trim()) {
+            return ogTitle.trim()
+        }
+
+        const title = doc.querySelector('title')?.textContent?.trim()
+        if (title) {
+            // Remove common Zenn suffixes
+            return title.replace(/\s*\|\s*Zenn$/, '').trim()
+        }
+
+        return null
+    }
+
+    getTurndownRules(): TurndownRule[] {
+        return [
+            COMMON_RULES.removeHeadingLinks,
+            COMMON_RULES.defaultCodeBlocks,
+            COMMON_RULES.removeImages,
+            // Zenn-specific rules
+            {
+                name: 'zennCodeBlocks',
+                filter: (node: Node) => {
+                    return node.nodeType === Node.ELEMENT_NODE &&
+                        (node as Element).tagName === 'PRE' &&
+                        !!(node as Element).querySelector('code')
+                },
+                replacement: (content: string, node: Node) => {
+                    const pre = node as HTMLElement
+                    const code = pre.querySelector('code')
+                    const codeContent = code?.textContent || content.trim()
+
+                    // Try to extract language from class
+                    const langClass = code?.className.match(/language-(\w+)/)
+                    const lang = langClass ? langClass[1] : ''
+
+                    return `\n\`\`\`${lang}\n${codeContent}\n\`\`\`\n`
+                },
+            },
+            {
+                name: 'zennCallouts',
+                filter: (node: Node) => {
+                    return node.nodeType === Node.ELEMENT_NODE &&
+                        (node as Element).classList.contains('msg')
+                },
+                replacement: (content: string, node: Node) => {
+                    const element = node as HTMLElement
+                    const type = element?.classList.contains('alert') ? '🚨' :
+                                element?.classList.contains('message') ? 'ℹ️' : '💡'
+                    return `\n> ${type} ${content.trim()}\n`
+                },
+            },
+        ]
+    }
+
+    getRemoveTags(): string[] {
+        return [
+            // Common elements
+            // 'nav',
+            // 'header[role="banner"]',
+            // 'footer[role="contentinfo"]',
+            // 'aside',
+            // 'script',
+            // 'style',
+            // Ads and tracking
+            '.google-auto-placed',
+            '.adsbygoogle',
+            '[class*="advertisement"]',
+            '[id*="ad"]',
+        ]
+    }
+}


### PR DESCRIPTION
- Add ZennSiteHandler with __NEXT_DATA__ JSON extraction
- Implement fallback to DOM-based extraction when JSON unavailable
- Add Zenn-specific Turndown rules for code blocks and callouts
- Create comprehensive test suite with 14 test cases
- Support both article and book URL patterns
- Integrate handler into site selection system

Key features:
- Primary: Extract from __NEXT_DATA__ script (recommended for Zenn)
- Fallback: DOM-based content extraction
- Custom callout conversion with emoji icons
- Language-aware code block processing

🤖 Generated with [Claude Code](https://claude.ai/code)